### PR TITLE
:gear: rely on tipi bundle utilities to package all missing libraries.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM tipibuild/tipi-ubuntu-1604-staging-694
 
 ENV OPENSSL_VERSION="1.1.1o"
 ENV PYTHON_VERSION="3.10.5"
@@ -45,6 +45,7 @@ RUN make install
 # a small homegrown script to bend the dynamic-module's RPATH so they find their own dependencies
 # ...why oh why
 COPY patch_so_rpaths.sh /patch_so_rpaths.sh
+RUN tipi bundle $INSTALL_DIR $INSTALL_DIR/lib 0 
 RUN chmod +x /patch_so_rpaths.sh \
  && /patch_so_rpaths.sh $INSTALL_DIR
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,9 +50,11 @@ WORKDIR $INSTALL_DIR
 COPY patch_so_rpaths.sh /patch_so_rpaths.sh
 RUN chmod +x /patch_so_rpaths.sh \
  && /patch_so_rpaths.sh $INSTALL_DIR
-RUN tipi bundle $INSTALL_DIR $INSTALL_DIR/lib 0 
+# Ensure RPATH is working relatively and doesn't rely on absolute RPATHs
+RUN mv $INSTALL_DIR $INSTALL_DIR-moved
+RUN tipi bundle $INSTALL_DIR-moved $INSTALL_DIR-moved/lib 0 
 
 # archive stuff so we can extract it easily
 RUN mkdir -p $OUTPUT_DIR \
- && cd $INSTALL_DIR \
+ && cd $INSTALL_DIR-moved \
  && zip -r $OUTPUT_DIR/tipi-python-$PYTHON_VERSION-w-openssl-$OPENSSL_VERSION.zip .  

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ WORKDIR Python-$PYTHON_VERSION
 # some of the magic that makes python "movable"
 # NOTE: by setting the RUNPATH (instead of RPATH) we still allow for monkeypatching
 # NOTE: we define $ORIGIN so that double-escaping-and-then-interpolation doesn't break everything... thanks many levels of autoconf+makefiles
-ENV ORIGIN="\$ORIGIN"
 ENV LDFLAGS_NODIST="-L$INSTALL_DIR/lib -Wl,--enable-new-dtags -Wl,-z,origin -Wl,-rpath='\$\$ORIGIN/../lib' -Wl,-rpath='\$\$ORIGIN'"
 
 # we enable PGO :top:

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSIO
  && tar xzvf Python-$PYTHON_VERSION.tgz \
  && cd Python-$PYTHON_VERSION 
 
-WORKDIR /Python-$PYTHON_VERSION
+WORKDIR Python-$PYTHON_VERSION
 
 # some of the magic that makes python "movable"
 # NOTE: by setting the RUNPATH (instead of RPATH) we still allow for monkeypatching

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,6 @@ RUN wget --no-check-certificate https://www.openssl.org/source/openssl-$OPENSSL_
  && make -j$(expr $(nproc) + 1) \
  && make install_sw
 
-RUN readelf -d /tipi-py/sysroot/bin/openssl | grep -i -E 'rpath|runpath'
-RUN echo "hell" && readelf -d /tipi-py/sysroot/lib/libssl.so.1.1 | grep -i -E 'rpath|runpath'
 RUN tipi bundle $INSTALL_DIR $INSTALL_DIR/lib 0 
 
 # python from source


### PR DESCRIPTION
This introduce the experimental bundle utilities to automatically package missing dynamic libraries for python.